### PR TITLE
Preventing joining cursive script character across HTML elements

### DIFF
--- a/lqt.js
+++ b/lqt.js
@@ -386,7 +386,8 @@ window.liquidThreads = {
 
 		editSubjectField.addClass( 'lqt-command-edit-subject' );
 
-		menu.append( editSubjectField );
+		// appending a space first to prevent cursive script character joining across elements
+		menu.append( ' ', editSubjectField );
 	},
 
 	'handleChangeSubject' : function ( e ) {


### PR DESCRIPTION
To fixing cursive character joining. It has no cleaner way and this approach is used before https://gerrit.wikimedia.org/r/#/c/84216/

![2013-10-25 11_56_16-support - translatewiki net - ux](https://f.cloud.github.com/assets/833473/1406331/279a15bc-3d4f-11e3-8f95-5067f6d6e6cb.png)
