### PR TITLE
Postgres DROP CONSTRAINT instead of DROP INDEX for thread_root_key

### DIFF
--- a/includes/Hooks.php
+++ b/includes/Hooks.php
@@ -482,7 +482,7 @@ class Hooks {
 				'changeField', 'thread_history', 'th_timestamp', 'TIMESTAMPTZ', 'th_timestamp::timestamp with time zone'
 			] );
 			$updater->addExtensionUpdate( [
-				'dropPgIndex', 'thread', 'thread_thread_root_key'
+				'dropConstraint', 'thread', 'thread_thread_root_key', 'unique'
 			] );
 			$updater->addExtensionUpdate( [
 				'renameIndex', 'thread', 'thread_root_page', 'thread_root'


### PR DESCRIPTION
Change thread_thread_root_key from index to constraint when dropping. In Postgres, thread_thread_root_key is a constraint and not an index.